### PR TITLE
feat: add benchmark to measure GetHash

### DIFF
--- a/src/N.SourceGenerators.UnionTypes.Benchmark/FooStructResultWithStructLayoutNoBoxing.cs
+++ b/src/N.SourceGenerators.UnionTypes.Benchmark/FooStructResultWithStructLayoutNoBoxing.cs
@@ -1,0 +1,301 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Explicit)]
+public struct FooStructResultWithStructLayoutNoBoxing : IEquatable<FooStructResultWithStructLayoutNoBoxing>
+{
+    private const int SuccessStructVariant = 1;
+    private const int ValidationErrorStructVariant = 2;
+    private const int NotFoundErrorStructVariant = 3;
+
+    [FieldOffset(0)] 
+    private readonly int _variant;
+
+    [FieldOffset(sizeof(int))] 
+    private readonly SuccessStruct _successStruct;
+
+    [FieldOffset(sizeof(int))] 
+    private readonly ValidationErrorStruct _validationErrorStruct;
+
+    [FieldOffset(sizeof(int))] 
+    private readonly NotFoundErrorStruct _notFoundErrorStruct;
+
+
+    public bool IsSuccessStruct => _variant == SuccessStructVariant;
+
+    public SuccessStruct AsSuccessStruct
+    {
+        get
+        {
+            if (_variant == SuccessStructVariant)
+                return _successStruct;
+
+            throw new InvalidOperationException("This is not a global::SuccessStruct");
+        }
+    }
+
+    public FooStructResultWithStructLayoutNoBoxing(SuccessStruct successStruct)
+    {
+        _variant = SuccessStructVariant;
+        _successStruct = successStruct;
+    }
+
+    public static implicit operator FooStructResultWithStructLayoutNoBoxing(SuccessStruct successStruct) =>
+        new FooStructResultWithStructLayoutNoBoxing(successStruct);
+
+    public static explicit operator SuccessStruct(FooStructResultWithStructLayoutNoBoxing value) => value.AsSuccessStruct;
+
+    public bool TryGetSuccessStruct([NotNullWhen(true)] out SuccessStruct? value)
+    {
+        if (_variant == SuccessStructVariant)
+        {
+            value = _successStruct;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool IsValidationErrorStruct => _variant == ValidationErrorStructVariant;
+
+    public ValidationErrorStruct AsValidationErrorStruct
+    {
+        get
+        {
+            if (_variant == ValidationErrorStructVariant)
+                return _validationErrorStruct;
+
+            throw new InvalidOperationException("This is not a global::ValidationErrorStruct");
+        }
+    }
+
+    public FooStructResultWithStructLayoutNoBoxing(ValidationErrorStruct validationErrorStruct)
+    {
+        _variant = ValidationErrorStructVariant;
+        _validationErrorStruct = validationErrorStruct;
+    }
+
+    public static implicit operator FooStructResultWithStructLayoutNoBoxing(ValidationErrorStruct validationErrorStruct) =>
+        new FooStructResultWithStructLayoutNoBoxing(validationErrorStruct);
+
+    public static explicit operator ValidationErrorStruct(FooStructResultWithStructLayoutNoBoxing value) =>
+        value.AsValidationErrorStruct;
+
+    public bool TryGetValidationErrorStruct([NotNullWhen(true)] out ValidationErrorStruct? value)
+    {
+        if (_variant == ValidationErrorStructVariant)
+        {
+            value = _validationErrorStruct;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool IsNotFoundErrorStruct => _variant == NotFoundErrorStructVariant;
+
+    public NotFoundErrorStruct AsNotFoundErrorStruct
+    {
+        get
+        {
+            if (_variant == NotFoundErrorStructVariant)
+                return _notFoundErrorStruct;
+
+            throw new InvalidOperationException(
+                "This is not a global::NotFoundErrorStruct");
+        }
+    }
+
+    public FooStructResultWithStructLayoutNoBoxing(NotFoundErrorStruct notFoundErrorStruct)
+    {
+        _variant = NotFoundErrorStructVariant;
+        _notFoundErrorStruct = notFoundErrorStruct;
+    }
+
+    public static implicit operator FooStructResultWithStructLayoutNoBoxing(NotFoundErrorStruct notFoundErrorStruct) =>
+        new FooStructResultWithStructLayoutNoBoxing(notFoundErrorStruct);
+
+    public static explicit operator NotFoundErrorStruct(FooStructResultWithStructLayoutNoBoxing value) =>
+        value.AsNotFoundErrorStruct;
+
+    public bool TryGetNotFoundErrorStruct([NotNullWhen(true)] out NotFoundErrorStruct? value)
+    {
+        if (_variant == NotFoundErrorStructVariant)
+        {
+            value = _notFoundErrorStruct;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public TOut Match<TOut>(Func<SuccessStruct, TOut> matchSuccessStruct,
+        Func<ValidationErrorStruct, TOut> matchValidationErrorStruct,
+        Func<NotFoundErrorStruct, TOut> matchNotFoundErrorStruct)
+    {
+        if (IsSuccessStruct)
+            return matchSuccessStruct(AsSuccessStruct);
+        if (IsValidationErrorStruct)
+            return matchValidationErrorStruct(AsValidationErrorStruct);
+        if (IsNotFoundErrorStruct)
+            return matchNotFoundErrorStruct(AsNotFoundErrorStruct);
+        throw new InvalidOperationException("Unknown type");
+    }
+
+    public async Task<TOut> MatchAsync<TOut>(Func<SuccessStruct, CancellationToken, Task<TOut>> matchSuccessStruct,
+        Func<ValidationErrorStruct, CancellationToken, Task<TOut>> matchValidationErrorStruct,
+        Func<NotFoundErrorStruct, CancellationToken, Task<TOut>> matchNotFoundErrorStruct, CancellationToken ct)
+    {
+        if (IsSuccessStruct)
+            return await matchSuccessStruct(AsSuccessStruct, ct).ConfigureAwait(false);
+        if (IsValidationErrorStruct)
+            return await matchValidationErrorStruct(AsValidationErrorStruct, ct).ConfigureAwait(false);
+        if (IsNotFoundErrorStruct)
+            return await matchNotFoundErrorStruct(AsNotFoundErrorStruct, ct).ConfigureAwait(false);
+        throw new InvalidOperationException("Unknown type");
+    }
+
+    public void Switch(Action<SuccessStruct> switchSuccessStruct,
+        Action<ValidationErrorStruct> switchValidationErrorStruct,
+        Action<NotFoundErrorStruct> switchNotFoundErrorStruct)
+    {
+        if (IsSuccessStruct)
+        {
+            switchSuccessStruct(AsSuccessStruct);
+            return;
+        }
+
+        if (IsValidationErrorStruct)
+        {
+            switchValidationErrorStruct(AsValidationErrorStruct);
+            return;
+        }
+
+        if (IsNotFoundErrorStruct)
+        {
+            switchNotFoundErrorStruct(AsNotFoundErrorStruct);
+            return;
+        }
+
+        throw new InvalidOperationException("Unknown type");
+    }
+
+    public async Task SwitchAsync(Func<SuccessStruct, CancellationToken, Task> switchSuccessStruct,
+        Func<ValidationErrorStruct, CancellationToken, Task> switchValidationErrorStruct,
+        Func<NotFoundErrorStruct, CancellationToken, Task> switchNotFoundErrorStruct, CancellationToken ct)
+    {
+        if (IsSuccessStruct)
+        {
+            await switchSuccessStruct(AsSuccessStruct, ct).ConfigureAwait(false);
+            return;
+        }
+
+        if (IsValidationErrorStruct)
+        {
+            await switchValidationErrorStruct(AsValidationErrorStruct, ct).ConfigureAwait(false);
+            return;
+        }
+
+        if (IsNotFoundErrorStruct)
+        {
+            await switchNotFoundErrorStruct(AsNotFoundErrorStruct, ct).ConfigureAwait(false);
+            return;
+        }
+
+        throw new InvalidOperationException("Unknown type");
+    }
+
+    public Type ValueType
+    {
+        get
+        {
+            if (IsSuccessStruct)
+                return typeof(SuccessStruct);
+            if (IsValidationErrorStruct)
+                return typeof(ValidationErrorStruct);
+            if (IsNotFoundErrorStruct)
+                return typeof(NotFoundErrorStruct);
+            throw new InvalidOperationException("Unknown type");
+        }
+    }
+    private Object InnerValue
+    {
+        get
+        {
+            if (IsSuccessStruct)
+                return AsSuccessStruct;
+            if (IsValidationErrorStruct)
+                return AsValidationErrorStruct;
+            if (IsNotFoundErrorStruct)
+                return AsNotFoundErrorStruct;
+            throw new InvalidOperationException("Unknown type");
+        }
+    }
+
+
+    private string InnerValueAlias
+    {
+        get
+        {
+            if (IsSuccessStruct)
+                return "SuccessStruct";
+            if (IsValidationErrorStruct)
+                return "ValidationErrorStruct";
+            if (IsNotFoundErrorStruct)
+                return "NotFoundErrorStruct";
+            throw new InvalidOperationException("Unknown type");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        if (IsSuccessStruct)
+            return AsSuccessStruct.GetHashCode();
+        if (IsValidationErrorStruct)
+            return AsValidationErrorStruct.GetHashCode();
+        if (IsNotFoundErrorStruct)
+            return AsNotFoundErrorStruct.GetHashCode();
+        throw new InvalidOperationException("Unknown type");
+    }
+
+    public static bool operator ==(FooStructResultWithStructLayoutNoBoxing left, FooStructResultWithStructLayoutNoBoxing right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(FooStructResultWithStructLayoutNoBoxing left, FooStructResultWithStructLayoutNoBoxing right)
+    {
+        return !left.Equals(right);
+    }
+
+    public bool Equals(FooStructResultWithStructLayoutNoBoxing other)
+    {
+        if (ValueType != other.ValueType)
+        {
+            return false;
+        }
+
+        if (IsSuccessStruct)
+            return EqualityComparer<SuccessStruct>.Default.Equals(AsSuccessStruct, other.AsSuccessStruct);
+        if (IsValidationErrorStruct)
+            return EqualityComparer<ValidationErrorStruct>.Default.Equals(AsValidationErrorStruct,
+                other.AsValidationErrorStruct);
+        if (IsNotFoundErrorStruct)
+            return EqualityComparer<NotFoundErrorStruct>.Default.Equals(AsNotFoundErrorStruct,
+                other.AsNotFoundErrorStruct);
+        throw new InvalidOperationException("Unknown type");
+    }
+
+    public override string ToString()
+    {
+        return $"{InnerValueAlias} - {InnerValue}";
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is FooStructResultWithStructLayout other && Equals(other);
+    }
+}

--- a/src/N.SourceGenerators.UnionTypes.Benchmark/Program.cs
+++ b/src/N.SourceGenerators.UnionTypes.Benchmark/Program.cs
@@ -56,6 +56,45 @@ public class ReadValueBenchmark
         _classLayout.AsValidationError;
 }
 
+[MemoryDiagnoser]
+public class HashBenchmark
+{
+    private readonly FooStructResult _struct;
+    private readonly FooResult _class;
+    private readonly FooResultLayout _classLayout;
+    private readonly FooStructResultWithStructLayout _structLayout;
+    private readonly FooStructResultWithStructLayoutNoBoxing _structLayoutNoBoxing;
+
+    public HashBenchmark()
+    {
+        _struct = new FooStructResult(new ValidationErrorStruct(42));
+        _class = new FooResult(new ValidationError("something went wrong"));
+        _classLayout = new FooResultLayout(new ValidationError("something went wrong"));
+        _structLayout = new FooStructResultWithStructLayout(new ValidationErrorStruct(42));
+        _structLayoutNoBoxing = new FooStructResultWithStructLayoutNoBoxing(new ValidationErrorStruct(42));
+    }
+
+    [Benchmark]
+    public int Struct() =>
+        _struct.GetHashCode();
+
+    [Benchmark]
+    public int WithLayout() =>
+        _structLayout.GetHashCode();
+
+    [Benchmark]
+    public int WithLayoutNoBoxing() =>
+        _structLayoutNoBoxing.GetHashCode();
+
+    [Benchmark(Baseline = true)]
+    public int Class() =>
+        _class.GetHashCode();
+
+    [Benchmark]
+    public int ClassLayout() =>
+        _classLayout.GetHashCode();
+}
+
 public record struct SuccessStruct(int Value);
 
 public record struct ValidationErrorStruct(int ErrorCode);

--- a/src/N.SourceGenerators.UnionTypes.Benchmark/run.ps1
+++ b/src/N.SourceGenerators.UnionTypes.Benchmark/run.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param (
-    [ValidateSet("Ctor", "ReadValue")]
+    [ValidateSet("Ctor", "ReadValue", "Hash")]
     [string]$Mode
 )
 
@@ -9,6 +9,7 @@ $Filter = ''
 switch ($Mode) {
     "Ctor" { $Filter = '*CtorBenchmark*' }
     "ReadValue" { $Filter = '*ReadValueBenchmark*' }
+    "Hash" { $Filter = '*HashBenchmark*' }
     Default {}
 }
 


### PR DESCRIPTION
I noticed that `GetHash` still uses an `object`, so tried to add a benchmark and the improvement is significant:

// * Summary *

BenchmarkDotNet=v0.13.4, OS=Windows 11 (10.0.22621.1105)
AMD Ryzen 9 5900HS with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
.NET SDK=7.0.102
  [Host]     : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
  Job-DRNVHW : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2

Runtime=.NET 7.0  Toolchain=net7.0  IterationCount=3
LaunchCount=1  WarmupCount=3

|             Method |      Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|------------------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
|             Struct | 11.511 ns |  7.585 ns | 0.4157 ns |  0.43 |    0.04 | 0.0029 |      24 B |          NA |
|         WithLayout | 10.225 ns |  5.764 ns | 0.3160 ns |  0.38 |    0.02 | 0.0029 |      24 B |          NA |
| WithLayoutNoBoxing |  4.158 ns |  2.832 ns | 0.1552 ns |  0.16 |    0.02 |      - |         - |          NA |
|              Class | 26.755 ns | 37.681 ns | 2.0654 ns |  1.00 |    0.00 |      - |         - |          NA |
|        ClassLayout | 25.655 ns | 33.121 ns | 1.8155 ns |  0.97 |    0.14 |      - |         - |          NA |